### PR TITLE
Fix Chinese IME input by replacing NSPopover with NSPanel

### DIFF
--- a/BarTranslate/BarTranslateApp.swift
+++ b/BarTranslate/BarTranslateApp.swift
@@ -48,7 +48,7 @@ class BarTranslate: ObservableObject {
 class AppDelegate: NSObject, NSApplicationDelegate {
   static private(set) var instance: AppDelegate!
   
-  var popover: NSPopover!
+  var panel: NSPanel!
   var statusBarItem: NSStatusItem!
   var hotkeyToggleApp: HotKey!
   var hotkeyToggleSettings: HotKey!
@@ -91,7 +91,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       key: key,
       modifiers: keyToNSEventModifierFlags(key: mod),
       keyDownHandler: {
-        self.togglePopover(nil)
+        self.togglePanel(nil)
       }
     )
   }
@@ -111,44 +111,77 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     
     let contentView = ContentView(BT: BT)
     
-    // Application Bubble
-    let popover = NSPopover()
-    popover.contentSize = NSSize(width: Constants.AppSize.width, height: Constants.AppSize.height)
-    popover.behavior = .transient
-    popover.contentViewController = NSHostingController(rootView: contentView)
-    self.popover = popover
-    
-    // Do not auto close popover when debugging
-    #if DEBUG
-    popover.behavior = .applicationDefined
-    #endif
-
+    // Application Panel
+    let panel = NSPanel(
+      contentRect: NSRect(x: 0, y: 0, width: Constants.AppSize.width, height: Constants.AppSize.height),
+      styleMask: [.titled, .fullSizeContentView],
+      backing: .buffered,
+      defer: false)
+    panel.isFloatingPanel = true
+    panel.level = .floating
+    panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
+    panel.contentViewController = NSHostingController(rootView: contentView)
+    panel.isMovableByWindowBackground = false
+    panel.backgroundColor = .clear
+    panel.titleVisibility = .hidden
+    panel.titlebarAppearsTransparent = true
+    panel.standardWindowButton(.closeButton)?.isHidden = true
+    panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
+    panel.standardWindowButton(.zoomButton)?.isHidden = true
+    panel.hasShadow = true
+    panel.delegate = self
+    self.panel = panel
     
     // Setup status bar item
     self.statusBarItem = NSStatusBar.system.statusItem(withLength: CGFloat(NSStatusItem.variableLength))
     if let button = self.statusBarItem.button {
       button.image = NSImage(named: menuBarIcon.id)
-      button.action = #selector(togglePopover(_:))
+      button.action = #selector(togglePanel(_:))
     }
     
     setupToggleAppHotkeys()
   }
   
-  // Show or hide BarTranslate
-  @objc func togglePopover(_ sender: AnyObject?) {
-    
-    if let button = self.statusBarItem.button {
-      if self.popover.isShown {
-        self.popover.performClose(sender)
-      } else {
-        self.popover.show(relativeTo: button.bounds, of: button, preferredEdge: NSRectEdge.minY)
-        
-        // Autofocus HTML input
-        if let webView = BT.webView, !webView.isHidden {
-          injectFocusScript(webView: webView, provider: translationProvider)
-        }
+  // Show or hide BarTranslate panel
+  @objc func togglePanel(_ sender: AnyObject?) {
+    if panel.isVisible {
+      panel.orderOut(sender)
+    } else {
+      positionPanel()
+      panel.makeKeyAndOrderFront(sender)
+      NSApp.activate(ignoringOtherApps: true)
+      
+      // Autofocus HTML input
+      if let webView = BT.webView, !webView.isHidden {
+        injectFocusScript(webView: webView, provider: translationProvider)
       }
     }
   }
+  
+  func positionPanel() {
+    guard let button = statusBarItem.button else { return }
+    guard let window = button.window else { return }
+    
+    // Convert button frame to screen coordinates
+    let buttonFrame = window.convertToScreen(button.convert(button.bounds, to: nil))
+    let panelSize = panel.frame.size
+    
+    // Position panel centered below the menu bar icon
+    let panelX = buttonFrame.midX - (panelSize.width / 2)
+    let panelY = buttonFrame.minY - panelSize.height - 5  // 5pt gap
+    
+    panel.setFrameOrigin(NSPoint(x: panelX, y: panelY))
+  }
+  
+  func panelDidResignKey(_ notification: Notification) {
+    panel.orderOut(nil)
+  }
 }
 
+extension AppDelegate: NSWindowDelegate {
+  func windowDidResignKey(_ notification: Notification) {
+    if let window = notification.object as? NSPanel, window == panel {
+      panelDidResignKey(notification)
+    }
+  }
+}

--- a/BarTranslate/BarTranslateApp.swift
+++ b/BarTranslate/BarTranslateApp.swift
@@ -30,6 +30,13 @@ struct BarTranslateApp: App {
   }
 }
 
+// MARK: - Panel Configuration
+
+private struct PanelConfig {
+  /// Gap between menu bar icon and panel (in points)
+  static let menuBarGap: CGFloat = 5
+}
+
 class BarTranslate: ObservableObject {
   @Published var currentView: CurrentContentView = .translate
   var webView: WKWebView?
@@ -51,7 +58,6 @@ class AppDelegate: NSObject, NSApplicationDelegate {
   var panel: NSPanel!
   var statusBarItem: NSStatusItem!
   var hotkeyToggleApp: HotKey!
-  var hotkeyToggleSettings: HotKey!
   
   var BT: BarTranslate = BarTranslate()
     
@@ -114,7 +120,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     // Application Panel
     let panel = NSPanel(
       contentRect: NSRect(x: 0, y: 0, width: Constants.AppSize.width, height: Constants.AppSize.height),
-      styleMask: [.titled, .fullSizeContentView],
+      styleMask: [.borderless],
       backing: .buffered,
       defer: false)
     panel.isFloatingPanel = true
@@ -123,14 +129,22 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     panel.contentViewController = NSHostingController(rootView: contentView)
     panel.isMovableByWindowBackground = false
     panel.backgroundColor = .clear
-    panel.titleVisibility = .hidden
-    panel.titlebarAppearsTransparent = true
-    panel.standardWindowButton(.closeButton)?.isHidden = true
-    panel.standardWindowButton(.miniaturizeButton)?.isHidden = true
-    panel.standardWindowButton(.zoomButton)?.isHidden = true
     panel.hasShadow = true
     panel.delegate = self
+    
+    // Apply rounded corners to match popover appearance
+    if let contentView = panel.contentView {
+      contentView.wantsLayer = true
+      contentView.layer?.cornerRadius = 12
+      contentView.layer?.masksToBounds = true
+    }
+    
     self.panel = panel
+    
+    // Do not auto-close panel when debugging
+    #if DEBUG
+    panel.hidesOnDeactivate = false
+    #endif
     
     // Setup status bar item
     self.statusBarItem = NSStatusBar.system.statusItem(withLength: CGFloat(NSStatusItem.variableLength))
@@ -167,8 +181,25 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     let panelSize = panel.frame.size
     
     // Position panel centered below the menu bar icon
-    let panelX = buttonFrame.midX - (panelSize.width / 2)
-    let panelY = buttonFrame.minY - panelSize.height - 5  // 5pt gap
+    var panelX = buttonFrame.midX - (panelSize.width / 2)
+    var panelY = buttonFrame.minY - panelSize.height - PanelConfig.menuBarGap
+    
+    // Ensure panel stays within screen boundaries
+    if let screen = NSScreen.main {
+      let screenFrame = screen.visibleFrame
+      
+      // Clamp horizontal position to stay on screen
+      if panelX < screenFrame.minX {
+        panelX = screenFrame.minX
+      } else if panelX + panelSize.width > screenFrame.maxX {
+        panelX = screenFrame.maxX - panelSize.width
+      }
+      
+      // Ensure panel doesn't go below screen bottom
+      if panelY < screenFrame.minY {
+        panelY = screenFrame.minY
+      }
+    }
     
     panel.setFrameOrigin(NSPoint(x: panelX, y: panelY))
   }

--- a/BarTranslate/views/ContentView.swift
+++ b/BarTranslate/views/ContentView.swift
@@ -39,11 +39,7 @@ struct ContentView: View {
       minHeight: Constants.AppSize.height,
       alignment: .topLeading
     )
-    // Color the popover arrow
-    .background(
-      Color.blue
-        .position(x: Constants.AppSize.width / 2, y: -Constants.AppSize.height / 2 + 10)
-    )
+    .background(Color(NSColor.windowBackgroundColor))
   }
   
   


### PR DESCRIPTION
Based on PR #60 from ThijmenDam/BarTranslate by @xniPh690 with additional fixes.

## Problem
NSPopover does not correctly display the Input Method Editor (IME) candidate window for Chinese and other East Asian input methods, making reliable text input impossible (issue #58).

## Solution
Replaced NSPopover with NSPanel while preserving the existing user experience.

## Changes Made
- Replace NSPopover with NSPanel to resolve IME candidate window issues
- Add screen boundary checks to keep panel positioned on-screen
- Restore DEBUG behavior (no auto-close during debugging)
- Use borderless style mask to eliminate extra title bar height (fixes the "double height" issue from original PR)
- Remove unused `hotkeyToggleSettings` property
- Fix background color for NSPanel context

## Credits
Original implementation by @xniPh690 in https://github.com/ThijmenDam/BarTranslate/pull/60

## Testing
- Build succeeds
- App launches and displays correctly
- Panel positions below menu bar icon
- Auto-dismisses when clicking outside (non-DEBUG builds)
- No extra title bar padding