### PR TITLE
Create Homebrew release pipeline for BarTranslateACO (Fixes #5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,163 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: "Release tag (vX.Y.Z)"
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Build and publish macOS release
+    runs-on: macos-14
+    env:
+      BARTRANSLATE_APP_NAME: BarTranslateACO
+      BARTRANSLATE_BUNDLE_IDENTIFIER: com.acoliver.BarTranslateACO
+      HOMEBREW_TAP_REPO: acoliver/homebrew-tap
+      HOMEBREW_CASK_TOKEN: bartranslate-aco
+    steps:
+      - name: Resolve release tag
+        id: release_tag
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_EVENT_NAME}" == "workflow_dispatch" ]]; then
+            release_tag="${{ inputs.release_tag }}"
+          else
+            release_tag="${GITHUB_REF_NAME}"
+          fi
+
+          if [[ ! "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+            echo "Release tag must look like vX.Y.Z (received: ${release_tag})" >&2
+            exit 1
+          fi
+
+          echo "release_tag=${release_tag}" >> "${GITHUB_OUTPUT}"
+
+      - name: Check out release tag
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ steps.release_tag.outputs.release_tag }}
+
+      - name: Select Xcode
+        shell: bash
+        run: |
+          set -euo pipefail
+          if [[ -d /Applications/Xcode_15.4.app ]]; then
+            sudo xcode-select -s /Applications/Xcode_15.4.app/Contents/Developer
+          fi
+          xcodebuild -version
+
+      - name: Validate Homebrew tap secret
+        shell: bash
+        env:
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          if [[ -z "${HOMEBREW_TAP_GITHUB_TOKEN}" ]]; then
+            echo "HOMEBREW_TAP_GITHUB_TOKEN is required to update acoliver/homebrew-tap" >&2
+            exit 1
+          fi
+
+      - name: Resolve signing mode
+        shell: bash
+        env:
+          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+        run: |
+          set -euo pipefail
+          if [[ -n "${APPLE_CERTIFICATE_P12_BASE64}" ]]; then
+            echo "BARTRANSLATE_SIGNING_MODE=developer-id" >> "${GITHUB_ENV}"
+          else
+            echo "BARTRANSLATE_SIGNING_MODE=ad-hoc" >> "${GITHUB_ENV}"
+          fi
+
+      - name: Import Developer ID certificate
+        if: ${{ env.BARTRANSLATE_SIGNING_MODE == 'developer-id' }}
+        shell: bash
+        env:
+          APPLE_CERTIFICATE_P12_BASE64: ${{ secrets.APPLE_CERTIFICATE_P12_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.APPLE_CERTIFICATE_PASSWORD }}
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+          APPLE_KEYCHAIN_PASSWORD: ${{ secrets.APPLE_KEYCHAIN_PASSWORD }}
+        run: |
+          set -euo pipefail
+          for secret_name in APPLE_CERTIFICATE_P12_BASE64 APPLE_CERTIFICATE_PASSWORD APPLE_TEAM_ID APPLE_ID APPLE_APP_SPECIFIC_PASSWORD; do
+            if [[ -z "${!secret_name}" ]]; then
+              echo "${secret_name} is required for Developer ID signing and notarization" >&2
+              exit 1
+            fi
+          done
+
+          if [[ -z "${APPLE_KEYCHAIN_PASSWORD}" ]]; then
+            APPLE_KEYCHAIN_PASSWORD="${GITHUB_RUN_ID}"
+          fi
+
+          keychain_path="${RUNNER_TEMP}/bartranslate-release.keychain-db"
+          certificate_path="${RUNNER_TEMP}/developer-id.p12"
+          echo "${APPLE_CERTIFICATE_P12_BASE64}" | base64 --decode > "${certificate_path}"
+          security create-keychain -p "${APPLE_KEYCHAIN_PASSWORD}" "${keychain_path}"
+          security set-keychain-settings -lut 21600 "${keychain_path}"
+          security unlock-keychain -p "${APPLE_KEYCHAIN_PASSWORD}" "${keychain_path}"
+          security import "${certificate_path}" -P "${APPLE_CERTIFICATE_PASSWORD}" -A -t cert -f pkcs12 -k "${keychain_path}"
+          security list-keychains -d user -s "${keychain_path}" login.keychain-db
+          security set-key-partition-list -S apple-tool:,apple: -s -k "${APPLE_KEYCHAIN_PASSWORD}" "${keychain_path}"
+
+      - name: Build package
+        shell: bash
+        env:
+          APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
+          APPLE_ID: ${{ secrets.APPLE_ID }}
+          APPLE_APP_SPECIFIC_PASSWORD: ${{ secrets.APPLE_APP_SPECIFIC_PASSWORD }}
+        run: |
+          set -euo pipefail
+          scripts/release/package_macos.sh "${{ steps.release_tag.outputs.release_tag }}"
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: bartranslate-aco-release
+          path: |
+            artifacts/release/*.zip
+            artifacts/release/SHA256SUMS.txt
+            artifacts/release/*.txt
+
+      - name: Create or update GitHub release
+        shell: bash
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          release_tag="${{ steps.release_tag.outputs.release_tag }}"
+          asset_name="$(cat artifacts/release/asset_name.txt)"
+          asset_path="$(cat artifacts/release/asset_path.txt)"
+
+          if gh release view "${release_tag}" >/dev/null 2>&1; then
+            gh release upload "${release_tag}" "${asset_path}" artifacts/release/SHA256SUMS.txt --clobber
+          else
+            gh release create "${release_tag}" "${asset_path}" artifacts/release/SHA256SUMS.txt \
+              --title "${release_tag}" \
+              --notes "BarTranslateACO ${release_tag} macOS release. Install with Homebrew cask bartranslate-aco from acoliver/homebrew-tap."
+          fi
+
+          gh release view "${release_tag}" --json tagName,url
+
+      - name: Update Homebrew cask
+        shell: bash
+        env:
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+          scripts/release/update_homebrew_tap.sh \
+            "${{ steps.release_tag.outputs.release_tag }}" \
+            "$(cat artifacts/release/asset_name.txt)" \
+            "$(cat artifacts/release/sha256.txt)"

--- a/.gitignore
+++ b/.gitignore
@@ -24,4 +24,6 @@ xcuserdata/
 
 # End of https://www.toptal.com/developers/gitignore/api/xcode
 
+artifacts/
+
 

--- a/BarTranslate.xcodeproj/project.pbxproj
+++ b/BarTranslate.xcodeproj/project.pbxproj
@@ -31,7 +31,7 @@
 		4585105A2A69BD0100C21BD0 /* KeysAndModifiers.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = KeysAndModifiers.swift; sourceTree = "<group>"; };
 		45921B262A791991007AAD78 /* Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Bundle.swift; sourceTree = "<group>"; };
 		45C035312A21263500E304FF /* Constants.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Constants.swift; sourceTree = "<group>"; };
-		45D1EF742A20DA2D0029FACD /* BarTranslate.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BarTranslate.app; sourceTree = BUILT_PRODUCTS_DIR; };
+		45D1EF742A20DA2D0029FACD /* BarTranslateACO.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BarTranslateACO.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		45D1EF772A20DA2D0029FACD /* BarTranslateApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BarTranslateApp.swift; sourceTree = "<group>"; };
 		45D1EF792A20DA2D0029FACD /* ContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ContentView.swift; sourceTree = "<group>"; };
 		45D1EF7B2A20DA300029FACD /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
@@ -76,7 +76,7 @@
 		45D1EF752A20DA2D0029FACD /* Products */ = {
 			isa = PBXGroup;
 			children = (
-				45D1EF742A20DA2D0029FACD /* BarTranslate.app */,
+				45D1EF742A20DA2D0029FACD /* BarTranslateACO.app */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -148,7 +148,7 @@
 				454BD6AF2A384AD20014F9EB /* HotKey */,
 			);
 			productName = BarTranslate;
-			productReference = 45D1EF742A20DA2D0029FACD /* BarTranslate.app */;
+			productReference = 45D1EF742A20DA2D0029FACD /* BarTranslateACO.app */;
 			productType = "com.apple.product-type.application";
 		};
 /* End PBXNativeTarget section */
@@ -294,7 +294,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = BarTranslate;
+				INFOPLIST_KEY_CFBundleDisplayName = BarTranslateACO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -303,8 +303,8 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 2.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = ThijmenDam.BarTranslate;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.acoliver.BarTranslateACO;
+				PRODUCT_NAME = BarTranslateACO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};
@@ -442,7 +442,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = BarTranslate;
+				INFOPLIST_KEY_CFBundleDisplayName = BarTranslateACO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -451,8 +451,8 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 2.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = ThijmenDam.BarTranslate;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.acoliver.BarTranslateACO;
+				PRODUCT_NAME = BarTranslateACO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};
@@ -473,7 +473,7 @@
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
-				INFOPLIST_KEY_CFBundleDisplayName = BarTranslate;
+				INFOPLIST_KEY_CFBundleDisplayName = BarTranslateACO;
 				INFOPLIST_KEY_LSApplicationCategoryType = "public.app-category.utilities";
 				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
@@ -482,8 +482,8 @@
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 2.1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = ThijmenDam.BarTranslate;
-				PRODUCT_NAME = "$(TARGET_NAME)";
+				PRODUCT_BUNDLE_IDENTIFIER = com.acoliver.BarTranslateACO;
+				PRODUCT_NAME = BarTranslateACO;
 				SWIFT_EMIT_LOC_STRINGS = YES;
 				SWIFT_VERSION = 5.0;
 			};

--- a/BarTranslate.xcodeproj/xcshareddata/xcschemes/BarTranslate (App Store).xcscheme
+++ b/BarTranslate.xcodeproj/xcshareddata/xcschemes/BarTranslate (App Store).xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "45D1EF732A20DA2D0029FACD"
-               BuildableName = "BarTranslate.app"
+               BuildableName = "BarTranslateACO.app"
                BlueprintName = "BarTranslate"
                ReferencedContainer = "container:BarTranslate.xcodeproj">
             </BuildableReference>
@@ -45,7 +45,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "45D1EF732A20DA2D0029FACD"
-            BuildableName = "BarTranslate.app"
+            BuildableName = "BarTranslateACO.app"
             BlueprintName = "BarTranslate"
             ReferencedContainer = "container:BarTranslate.xcodeproj">
          </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "45D1EF732A20DA2D0029FACD"
-            BuildableName = "BarTranslate.app"
+            BuildableName = "BarTranslateACO.app"
             BlueprintName = "BarTranslate"
             ReferencedContainer = "container:BarTranslate.xcodeproj">
          </BuildableReference>

--- a/BarTranslate.xcodeproj/xcshareddata/xcschemes/BarTranslate (Debug).xcscheme
+++ b/BarTranslate.xcodeproj/xcshareddata/xcschemes/BarTranslate (Debug).xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "45D1EF732A20DA2D0029FACD"
-               BuildableName = "BarTranslate.app"
+               BuildableName = "BarTranslateACO.app"
                BlueprintName = "BarTranslate"
                ReferencedContainer = "container:BarTranslate.xcodeproj">
             </BuildableReference>
@@ -45,7 +45,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "45D1EF732A20DA2D0029FACD"
-            BuildableName = "BarTranslate.app"
+            BuildableName = "BarTranslateACO.app"
             BlueprintName = "BarTranslate"
             ReferencedContainer = "container:BarTranslate.xcodeproj">
          </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "45D1EF732A20DA2D0029FACD"
-            BuildableName = "BarTranslate.app"
+            BuildableName = "BarTranslateACO.app"
             BlueprintName = "BarTranslate"
             ReferencedContainer = "container:BarTranslate.xcodeproj">
          </BuildableReference>

--- a/BarTranslate.xcodeproj/xcshareddata/xcschemes/BarTranslate (GitHub).xcscheme
+++ b/BarTranslate.xcodeproj/xcshareddata/xcschemes/BarTranslate (GitHub).xcscheme
@@ -15,7 +15,7 @@
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "45D1EF732A20DA2D0029FACD"
-               BuildableName = "BarTranslate.app"
+               BuildableName = "BarTranslateACO.app"
                BlueprintName = "BarTranslate"
                ReferencedContainer = "container:BarTranslate.xcodeproj">
             </BuildableReference>
@@ -45,7 +45,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "45D1EF732A20DA2D0029FACD"
-            BuildableName = "BarTranslate.app"
+            BuildableName = "BarTranslateACO.app"
             BlueprintName = "BarTranslate"
             ReferencedContainer = "container:BarTranslate.xcodeproj">
          </BuildableReference>
@@ -62,7 +62,7 @@
          <BuildableReference
             BuildableIdentifier = "primary"
             BlueprintIdentifier = "45D1EF732A20DA2D0029FACD"
-            BuildableName = "BarTranslate.app"
+            BuildableName = "BarTranslateACO.app"
             BlueprintName = "BarTranslate"
             ReferencedContainer = "container:BarTranslate.xcodeproj">
          </BuildableReference>

--- a/BarTranslate/views/SettingsView.swift
+++ b/BarTranslate/views/SettingsView.swift
@@ -97,7 +97,7 @@ struct SettingsView: View {
                     #if !APPSTORE
                     SettingsRow(label: "Updates") {
                         Link("Check for updates",
-                             destination: URL(string: "https://github.com/ThijmenDam/BarTranslate/releases")!)
+                             destination: URL(string: "https://github.com/acoliver/BarTranslate/releases")!)
                         .font(.system(size: 12))
                     }
                     #endif

--- a/README.md
+++ b/README.md
@@ -23,16 +23,29 @@ By downloading BarTranslate from the App Store, you support the project with a s
 </a>
 
 
+## Installation (Homebrew)
+
+This fork is distributed with a fork-specific Homebrew cask so it can coexist with upstream BarTranslate:
+
+```sh
+brew tap acoliver/tap
+brew install --cask bartranslate-aco
+```
+
+The cask installs `BarTranslateACO.app`.
+
 ## Installation (manual)
 
-1. Refer to the [latest releases](https://github.com/ThijmenDam/BarTranslate/releases).
-2. Download BarTranslate.zip.
+1. Refer to the [latest releases](https://github.com/acoliver/BarTranslate/releases).
+2. Download `bartranslate-aco-vX.Y.Z-universal-apple-darwin.zip`.
 3. Unzip the file.
-4. Place BarTranslate.app in your Applications folder.
-5. Run BarTranslate.app.
+4. Place `BarTranslateACO.app` in your Applications folder.
+5. Run `BarTranslateACO.app`.
 6. Happy translating!
 
-## Features
+Release maintainers should see [docs/release.md](docs/release.md) for signing, notarization, and Homebrew tap secrets.
+
+
 
 Feel free to [share your ideas](https://github.com/ThijmenDam/BarTranslate/discussions)!
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -21,16 +21,29 @@ By downloading BarTranslate from the App Store, you support the project with a s
 </a>
 
 
+## Installation (Homebrew)
+
+This fork is distributed with a fork-specific Homebrew cask so it can coexist with upstream BarTranslate:
+
+```sh
+brew tap acoliver/tap
+brew install --cask bartranslate-aco
+```
+
+The cask installs `BarTranslateACO.app`.
+
 ## Installation (manual)
 
-1. Refer to the [latest releases](https://github.com/ThijmenDam/BarTranslate/releases).
-2. Download BarTranslate.zip.
+1. Refer to the [latest releases](https://github.com/acoliver/BarTranslate/releases).
+2. Download `bartranslate-aco-vX.Y.Z-universal-apple-darwin.zip`.
 3. Unzip the file.
-4. Place BarTranslate.app in your Applications folder.
-5. Run BarTranslate.app.
+4. Place `BarTranslateACO.app` in your Applications folder.
+5. Run `BarTranslateACO.app`.
 6. Happy translating!
 
-## Features
+Release maintainers should see [release.md](release.md) for signing, notarization, and Homebrew tap secrets.
+
+
 
 Feel free to [share your ideas](https://github.com/ThijmenDam/BarTranslate/discussions)!
 

--- a/docs/_layouts/default.html
+++ b/docs/_layouts/default.html
@@ -23,7 +23,7 @@
     <h2 class="project-tagline">{{ page.description | default: site.description | default: site.github.project_tagline }}</h2>
     {% if site.github.is_project_page %}
     <a href="{{ site.github.repository_url }}" class="btn">View on GitHub</a>
-    <a href="https://github.com/ThijmenDam/BarTranslate/releases" class="btn">Download</a>
+    <a href="https://github.com/acoliver/BarTranslate/releases" class="btn">Download</a>
     {% endif %}
 </header>
 <main id="content" class="main-content" role="main">

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,0 +1,85 @@
+# Release process
+
+This fork publishes macOS releases as a Homebrew cask with a fork-specific identity:
+
+- Tap repo: `acoliver/homebrew-tap`
+- Cask token: `bartranslate-aco`
+- App name: `BarTranslateACO.app`
+- Bundle identifier: `com.acoliver.BarTranslateACO`
+
+Release artifacts are created by `.github/workflows/release.yml` and packaged by `scripts/release/package_macos.sh`.
+
+## Creating a release
+
+Create and push a semver tag with a leading `v`:
+
+```sh
+git tag vX.Y.Z
+git push origin vX.Y.Z
+```
+
+The workflow can also be started manually from GitHub Actions with the `release_tag` input set to the same `vX.Y.Z` format. Non-semver tags are rejected.
+
+The workflow will:
+
+1. check out the requested tag,
+2. build the `BarTranslate (GitHub)` Xcode scheme in the `Release (GitHub)` configuration,
+3. set the app version from the tag,
+4. package `BarTranslateACO.app` as `bartranslate-aco-vX.Y.Z-universal-apple-darwin.zip`,
+5. verify the code signature,
+6. upload the zip and `SHA256SUMS.txt` to the GitHub release, and
+7. update `Casks/bartranslate-aco.rb` in `acoliver/homebrew-tap`.
+
+## Required secret
+
+The Homebrew tap update always requires this repository secret:
+
+- `HOMEBREW_TAP_GITHUB_TOKEN`: a GitHub token that can clone, commit to, and push to `acoliver/homebrew-tap`.
+
+## Signing modes
+
+The release workflow supports two signing modes.
+
+### Ad-hoc signing
+
+If no Developer ID certificate secret is configured, the workflow uses ad-hoc signing. This keeps releases reproducible without Apple Developer Program credentials, but users may see Gatekeeper warnings because the app is not notarized.
+
+### Developer ID signing and notarization
+
+If `APPLE_CERTIFICATE_P12_BASE64` is set, the workflow switches to Developer ID signing and notarization. Configure all of these secrets together:
+
+- `APPLE_CERTIFICATE_P12_BASE64`: base64-encoded Developer ID Application `.p12` certificate.
+- `APPLE_CERTIFICATE_PASSWORD`: password for the `.p12` file.
+- `APPLE_TEAM_ID`: Apple Developer Team ID.
+- `APPLE_ID`: Apple ID used with notarization.
+- `APPLE_APP_SPECIFIC_PASSWORD`: app-specific password for the Apple ID.
+- `APPLE_KEYCHAIN_PASSWORD`: optional temporary CI keychain password. If omitted, the workflow uses the GitHub run ID.
+
+Developer ID releases are submitted with `xcrun notarytool`, stapled with `xcrun stapler`, and checked with `spctl` before the final zip is created.
+
+## Local package test
+
+On macOS with Xcode installed, run:
+
+```sh
+scripts/release/package_macos.sh vX.Y.Z
+```
+
+By default this produces an ad-hoc signed artifact under `artifacts/release`. To test Developer ID signing locally, export the Apple variables used by the workflow and set:
+
+```sh
+export BARTRANSLATE_SIGNING_MODE=developer-id
+```
+
+Set `BARTRANSLATE_NOTARIZE=0` to skip notarization during a local Developer ID packaging smoke test.
+
+## Homebrew installation
+
+After a successful release and tap update:
+
+```sh
+brew tap acoliver/tap
+brew install --cask bartranslate-aco
+```
+
+The cask installs `BarTranslateACO.app` and zaps preferences at `~/Library/Preferences/com.acoliver.BarTranslateACO.plist`.

--- a/scripts/release/package_macos.sh
+++ b/scripts/release/package_macos.sh
@@ -1,0 +1,144 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 vX.Y.Z" >&2
+}
+
+if [[ $# -ne 1 ]]; then
+  usage
+  exit 64
+fi
+
+release_tag="$1"
+if [[ ! "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Release tag must look like vX.Y.Z (received: ${release_tag})" >&2
+  exit 64
+fi
+
+version="${release_tag#v}"
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+artifact_dir="${repo_root}/artifacts/release"
+derived_data_path="${artifact_dir}/DerivedData"
+archive_path="${artifact_dir}/BarTranslateACO.xcarchive"
+export_path="${artifact_dir}/export"
+unsigned_app_path="${artifact_dir}/unsigned-app/BarTranslateACO.app"
+app_path="${export_path}/BarTranslateACO.app"
+asset_name="bartranslate-aco-${release_tag}-universal-apple-darwin.zip"
+asset_path="${artifact_dir}/${asset_name}"
+signing_mode="${BARTRANSLATE_SIGNING_MODE:-ad-hoc}"
+configuration="Release (GitHub)"
+scheme="BarTranslate (GitHub)"
+project_path="${repo_root}/BarTranslate.xcodeproj"
+bundle_identifier="${BARTRANSLATE_BUNDLE_IDENTIFIER:-com.acoliver.BarTranslateACO}"
+app_display_name="${BARTRANSLATE_APP_NAME:-BarTranslateACO}"
+team_id="${APPLE_TEAM_ID:-}"
+signing_identity="${APPLE_SIGNING_IDENTITY:-}"
+notary_zip_path="${artifact_dir}/notarization-${asset_name}"
+
+rm -rf "${artifact_dir}"
+mkdir -p "${artifact_dir}" "$(dirname "${unsigned_app_path}")"
+
+common_build_settings=(
+  MARKETING_VERSION="${version}"
+  CURRENT_PROJECT_VERSION="${GITHUB_RUN_NUMBER:-1}"
+  PRODUCT_BUNDLE_IDENTIFIER="${bundle_identifier}"
+  PRODUCT_NAME="${app_display_name}"
+  INFOPLIST_KEY_CFBundleDisplayName="${app_display_name}"
+)
+
+if [[ "${signing_mode}" == "developer-id" ]]; then
+  if [[ -z "${team_id}" ]]; then
+    echo "APPLE_TEAM_ID is required when BARTRANSLATE_SIGNING_MODE=developer-id" >&2
+    exit 1
+  fi
+
+  if [[ -z "${signing_identity}" ]]; then
+    signing_identity="Developer ID Application"
+  fi
+
+  xcodebuild archive \
+    -project "${project_path}" \
+    -scheme "${scheme}" \
+    -configuration "${configuration}" \
+    -archivePath "${archive_path}" \
+    -destination "generic/platform=macOS" \
+    -derivedDataPath "${derived_data_path}" \
+    CODE_SIGN_STYLE=Manual \
+    CODE_SIGN_IDENTITY="${signing_identity}" \
+    DEVELOPMENT_TEAM="${team_id}" \
+    "${common_build_settings[@]}"
+
+  cat > "${artifact_dir}/ExportOptions.plist" <<PLIST
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+  <key>method</key>
+  <string>developer-id</string>
+  <key>signingStyle</key>
+  <string>manual</string>
+  <key>teamID</key>
+  <string>${team_id}</string>
+  <key>stripSwiftSymbols</key>
+  <true/>
+</dict>
+</plist>
+PLIST
+
+  xcodebuild -exportArchive \
+    -archivePath "${archive_path}" \
+    -exportPath "${export_path}" \
+    -exportOptionsPlist "${artifact_dir}/ExportOptions.plist"
+else
+  xcodebuild archive \
+    -project "${project_path}" \
+    -scheme "${scheme}" \
+    -configuration "${configuration}" \
+    -archivePath "${archive_path}" \
+    -destination "generic/platform=macOS" \
+    -derivedDataPath "${derived_data_path}" \
+    CODE_SIGN_STYLE=Manual \
+    CODE_SIGN_IDENTITY=- \
+    "${common_build_settings[@]}"
+
+  ditto "${archive_path}/Products/Applications/BarTranslateACO.app" "${unsigned_app_path}"
+  codesign --force --deep --sign - "${unsigned_app_path}"
+  mkdir -p "${export_path}"
+  ditto "${unsigned_app_path}" "${app_path}"
+fi
+
+if [[ ! -d "${app_path}" ]]; then
+  echo "Expected app bundle was not produced at ${app_path}" >&2
+  exit 1
+fi
+
+codesign --verify --deep --strict --verbose=2 "${app_path}"
+
+if [[ "${signing_mode}" == "developer-id" && "${BARTRANSLATE_NOTARIZE:-1}" != "0" ]]; then
+  if [[ -z "${APPLE_ID:-}" || -z "${APPLE_APP_SPECIFIC_PASSWORD:-}" || -z "${team_id}" ]]; then
+    echo "APPLE_ID, APPLE_APP_SPECIFIC_PASSWORD, and APPLE_TEAM_ID are required for notarization" >&2
+    exit 1
+  fi
+
+  ditto -c -k --keepParent "${app_path}" "${notary_zip_path}"
+  xcrun notarytool submit "${notary_zip_path}" \
+    --apple-id "${APPLE_ID}" \
+    --password "${APPLE_APP_SPECIFIC_PASSWORD}" \
+    --team-id "${team_id}" \
+    --wait
+  xcrun stapler staple "${app_path}"
+  spctl --assess --type execute --verbose "${app_path}"
+fi
+
+ditto -c -k --keepParent "${app_path}" "${asset_path}"
+sha256="$(shasum -a 256 "${asset_path}" | awk '{print $1}')"
+
+printf "%s  %s\n" "${sha256}" "${asset_name}" > "${artifact_dir}/SHA256SUMS.txt"
+printf "%s" "${asset_name}" > "${artifact_dir}/asset_name.txt"
+printf "%s" "${asset_path}" > "${artifact_dir}/asset_path.txt"
+printf "%s" "${sha256}" > "${artifact_dir}/sha256.txt"
+printf "%s" "${version}" > "${artifact_dir}/version.txt"
+
+echo "Packaged ${asset_path}"
+echo "SHA256 ${sha256}"

--- a/scripts/release/update_homebrew_tap.sh
+++ b/scripts/release/update_homebrew_tap.sh
@@ -1,0 +1,83 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+usage() {
+  echo "usage: $0 vX.Y.Z ASSET_NAME SHA256" >&2
+}
+
+if [[ $# -ne 3 ]]; then
+  usage
+  exit 64
+fi
+
+release_tag="$1"
+asset_name="$2"
+asset_sha256="$3"
+
+if [[ ! "${release_tag}" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
+  echo "Release tag must look like vX.Y.Z (received: ${release_tag})" >&2
+  exit 64
+fi
+
+if [[ ! "${asset_sha256}" =~ ^[0-9a-f]{64}$ ]]; then
+  echo "SHA256 must be 64 lowercase hexadecimal characters" >&2
+  exit 64
+fi
+
+if [[ -z "${GITHUB_REPOSITORY:-}" ]]; then
+  echo "GITHUB_REPOSITORY is required" >&2
+  exit 1
+fi
+
+if [[ -z "${HOMEBREW_TAP_GITHUB_TOKEN:-}" ]]; then
+  echo "HOMEBREW_TAP_GITHUB_TOKEN is required" >&2
+  exit 1
+fi
+
+version="${release_tag#v}"
+homebrew_tap_repo="${HOMEBREW_TAP_REPO:-acoliver/homebrew-tap}"
+cask_token="${HOMEBREW_CASK_TOKEN:-bartranslate-aco}"
+app_name="${BARTRANSLATE_APP_NAME:-BarTranslateACO}"
+bundle_identifier="${BARTRANSLATE_BUNDLE_IDENTIFIER:-com.acoliver.BarTranslateACO}"
+tap_dir="$(mktemp -d)"
+
+cleanup() {
+  rm -rf "${tap_dir}"
+}
+trap cleanup EXIT
+
+git clone "https://x-access-token:${HOMEBREW_TAP_GITHUB_TOKEN}@github.com/${homebrew_tap_repo}.git" "${tap_dir}"
+
+mkdir -p "${tap_dir}/Casks"
+cask_path="${tap_dir}/Casks/${cask_token}.rb"
+
+cat > "${cask_path}" <<RUBY
+cask "${cask_token}" do
+  version "${version}"
+  sha256 "${asset_sha256}"
+
+  url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${release_tag}/${asset_name}"
+  name "${app_name}"
+  desc "macOS menu bar translation app (ACO fork)"
+  homepage "https://github.com/${GITHUB_REPOSITORY}"
+
+  app "${app_name}.app"
+
+  zap trash: [
+    "~/Library/Preferences/${bundle_identifier}.plist",
+  ]
+end
+RUBY
+
+cd "${tap_dir}"
+git config user.name "${GIT_AUTHOR_NAME:-github-actions[bot]}"
+git config user.email "${GIT_AUTHOR_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
+git add "${cask_path}"
+
+if git diff --cached --quiet; then
+  echo "Homebrew cask ${cask_token} is already up to date"
+  exit 0
+fi
+
+git commit -m "${cask_token} ${version}"
+git push origin HEAD


### PR DESCRIPTION
## Summary
- add a tag/manual release workflow for BarTranslateACO
- package the macOS app as a fork-specific Homebrew cask artifact
- update acoliver/homebrew-tap automatically from releases
- document required Homebrew and optional Developer ID secrets

## Verification
- ruby YAML parse for .github/workflows/release.yml
- bash syntax checks for release scripts
- xcodebuild -list -project BarTranslate.xcodeproj
- local package smoke test with v9.9.9 before cleanup

Fixes #5