### PR TITLE
Install BarTranslateACO through Homebrew formula (Fixes #5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,7 +22,7 @@ jobs:
       BARTRANSLATE_APP_NAME: BarTranslateACO
       BARTRANSLATE_BUNDLE_IDENTIFIER: com.acoliver.BarTranslateACO
       HOMEBREW_TAP_REPO: acoliver/homebrew-tap
-      HOMEBREW_CASK_TOKEN: bartranslate-aco
+      HOMEBREW_FORMULA_NAME: bartranslate-aco
     steps:
       - name: Resolve release tag
         id: release_tag
@@ -146,12 +146,12 @@ jobs:
           else
             gh release create "${release_tag}" "${asset_path}" artifacts/release/SHA256SUMS.txt \
               --title "${release_tag}" \
-              --notes "BarTranslateACO ${release_tag} macOS release. Install with Homebrew cask bartranslate-aco from acoliver/homebrew-tap."
+              --notes "BarTranslateACO ${release_tag} macOS release. Install with Homebrew formula bartranslate-aco from acoliver/homebrew-tap."
           fi
 
           gh release view "${release_tag}" --json tagName,url
 
-      - name: Update Homebrew cask
+      - name: Update Homebrew formula
         shell: bash
         env:
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ By downloading BarTranslate from the App Store, you support the project with a s
 
 ## Installation (Homebrew)
 
-This fork is distributed with a fork-specific Homebrew cask so it can coexist with upstream BarTranslate:
+This fork is distributed with a fork-specific Homebrew formula so it can coexist with upstream BarTranslate:
 
 ```sh
 brew tap acoliver/tap
-brew install --cask bartranslate-aco
+brew install bartranslate-aco
 ```
 
-The cask installs `BarTranslateACO.app`.
+The formula installs `BarTranslateACO.app` under Homebrew's prefix and provides a `bartranslate-aco` launcher script.
 
 ## Installation (manual)
 

--- a/docs/README.md
+++ b/docs/README.md
@@ -23,14 +23,14 @@ By downloading BarTranslate from the App Store, you support the project with a s
 
 ## Installation (Homebrew)
 
-This fork is distributed with a fork-specific Homebrew cask so it can coexist with upstream BarTranslate:
+This fork is distributed with a fork-specific Homebrew formula so it can coexist with upstream BarTranslate:
 
 ```sh
 brew tap acoliver/tap
-brew install --cask bartranslate-aco
+brew install bartranslate-aco
 ```
 
-The cask installs `BarTranslateACO.app`.
+The formula installs `BarTranslateACO.app` under Homebrew's prefix and provides a `bartranslate-aco` launcher script.
 
 ## Installation (manual)
 

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,9 +1,9 @@
 # Release process
 
-This fork publishes macOS releases as a Homebrew cask with a fork-specific identity:
+This fork publishes macOS releases as a Homebrew formula with a fork-specific identity:
 
 - Tap repo: `acoliver/homebrew-tap`
-- Cask token: `bartranslate-aco`
+- Formula name: `bartranslate-aco`
 - App name: `BarTranslateACO.app`
 - Bundle identifier: `com.acoliver.BarTranslateACO`
 
@@ -28,7 +28,7 @@ The workflow will:
 4. package `BarTranslateACO.app` as `bartranslate-aco-vX.Y.Z-universal-apple-darwin.zip`,
 5. verify the code signature,
 6. upload the zip and `SHA256SUMS.txt` to the GitHub release, and
-7. update `Casks/bartranslate-aco.rb` in `acoliver/homebrew-tap`.
+7. update `Formula/bartranslate-aco.rb` in `acoliver/homebrew-tap`.
 
 ## Required secret
 
@@ -79,7 +79,7 @@ After a successful release and tap update:
 
 ```sh
 brew tap acoliver/tap
-brew install --cask bartranslate-aco
+brew install bartranslate-aco
 ```
 
-The cask installs `BarTranslateACO.app` and zaps preferences at `~/Library/Preferences/com.acoliver.BarTranslateACO.plist`.
+The formula installs `BarTranslateACO.app` under Homebrew's prefix and provides a `bartranslate-aco` launcher script.

--- a/scripts/release/update_homebrew_tap.sh
+++ b/scripts/release/update_homebrew_tap.sh
@@ -36,7 +36,9 @@ fi
 
 version="${release_tag#v}"
 homebrew_tap_repo="${HOMEBREW_TAP_REPO:-acoliver/homebrew-tap}"
-cask_token="${HOMEBREW_CASK_TOKEN:-bartranslate-aco}"
+formula_name="${HOMEBREW_FORMULA_NAME:-bartranslate-aco}"
+formula_class_name="$(echo "${formula_name}" | sed -E 's/[^a-zA-Z0-9]+/ /g' | awk '{for(i=1;i<=NF;i++){printf toupper(substr($i,1,1)) tolower(substr($i,2))}}')"
+release_url="https://github.com/${GITHUB_REPOSITORY}/releases/download/${release_tag}/${asset_name}"
 app_name="${BARTRANSLATE_APP_NAME:-BarTranslateACO}"
 bundle_identifier="${BARTRANSLATE_BUNDLE_IDENTIFIER:-com.acoliver.BarTranslateACO}"
 tap_dir="$(mktemp -d)"
@@ -48,36 +50,58 @@ trap cleanup EXIT
 
 git clone "https://x-access-token:${HOMEBREW_TAP_GITHUB_TOKEN}@github.com/${homebrew_tap_repo}.git" "${tap_dir}"
 
-mkdir -p "${tap_dir}/Casks"
-cask_path="${tap_dir}/Casks/${cask_token}.rb"
+mkdir -p "${tap_dir}/Formula"
+formula_path="${tap_dir}/Formula/${formula_name}.rb"
 
-cat > "${cask_path}" <<RUBY
-cask "${cask_token}" do
-  version "${version}"
-  sha256 "${asset_sha256}"
-
-  url "https://github.com/${GITHUB_REPOSITORY}/releases/download/${release_tag}/${asset_name}"
-  name "${app_name}"
+cat > "${formula_path}" <<RUBY
+class ${formula_class_name} < Formula
   desc "macOS menu bar translation app (ACO fork)"
   homepage "https://github.com/${GITHUB_REPOSITORY}"
+  url "${release_url}"
+  version "${version}"
+  sha256 "${asset_sha256}"
+  license "GPL-3.0-only"
 
-  app "${app_name}.app"
+  def install
+    prefix.install "${app_name}.app"
+    bin.install_symlink prefix/"${app_name}.app/Contents/MacOS/${app_name}" => "${formula_name}"
+  end
 
-  zap trash: [
-    "~/Library/Preferences/${bundle_identifier}.plist",
-  ]
+  def caveats
+    <<~EOS
+      ${app_name}.app was installed to:
+        #{prefix}/#{"${app_name}.app"}
+
+      To launch it from Finder, open that app bundle directly. To launch it from
+      a shell, run:
+        ${formula_name}
+    EOS
+  end
+
+  def uninstall
+    system "defaults", "delete", "${bundle_identifier}" rescue nil
+  end
+
+  test do
+    assert_predicate prefix/"${app_name}.app/Contents/MacOS/${app_name}", :exist?
+    assert_predicate bin/"${formula_name}", :exist?
+  end
 end
 RUBY
 
 cd "${tap_dir}"
+if [[ -f "Casks/${formula_name}.rb" ]]; then
+  git rm "Casks/${formula_name}.rb"
+fi
+
 git config user.name "${GIT_AUTHOR_NAME:-github-actions[bot]}"
 git config user.email "${GIT_AUTHOR_EMAIL:-41898282+github-actions[bot]@users.noreply.github.com}"
-git add "${cask_path}"
+git add "${formula_path}"
 
 if git diff --cached --quiet; then
-  echo "Homebrew cask ${cask_token} is already up to date"
+  echo "Homebrew formula ${formula_name} is already up to date"
   exit 0
 fi
 
-git commit -m "${cask_token} ${version}"
+git commit -m "${formula_name} ${version}"
 git push origin HEAD


### PR DESCRIPTION
## Summary
- switch the Homebrew tap update from Casks/bartranslate-aco.rb to Formula/bartranslate-aco.rb
- install BarTranslateACO.app under the Homebrew prefix and symlink bartranslate-aco onto PATH
- remove the previous cask from the tap when publishing the formula
- update release docs and README install commands to use brew install bartranslate-aco

## Verification
- ruby YAML parse for .github/workflows/release.yml
- bash syntax checks for release scripts

Fixes #5