### PR TITLE
Fix BarTranslateACO menu bar visibility (Fixes #5)

### DIFF
--- a/BarTranslate/BarTranslateApp.swift
+++ b/BarTranslate/BarTranslateApp.swift
@@ -135,7 +135,10 @@ class AppDelegate: NSObject, NSApplicationDelegate {
 
   func updateMenuBarIcon() {
     if let button = self.statusBarItem.button {
-      button.image = NSImage(named: menuBarIcon.id)
+      let image = NSImage(named: menuBarIcon.id) ?? NSImage(systemSymbolName: "character.book.closed", accessibilityDescription: "BarTranslateACO")
+      image?.isTemplate = true
+      button.image = image
+      button.imagePosition = .imageOnly
     }
   }
 
@@ -154,7 +157,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       backing: .buffered,
       defer: false)
     panel.isFloatingPanel = true
-    panel.level = .floating
+    panel.level = .popUpMenu
     panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
     panel.contentViewController = NSHostingController(rootView: contentView)
     panel.isMovableByWindowBackground = false
@@ -177,11 +180,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     #endif
 
     // Setup status bar item
-    self.statusBarItem = NSStatusBar.system.statusItem(withLength: CGFloat(NSStatusItem.variableLength))
+    self.statusBarItem = NSStatusBar.system.statusItem(withLength: CGFloat(NSStatusItem.squareLength))
     if let button = self.statusBarItem.button {
-      button.image = NSImage(named: menuBarIcon.id)
       button.action = #selector(togglePanel(_:))
     }
+    updateMenuBarIcon()
 
     setupToggleAppHotkeys()
 


### PR DESCRIPTION
## Summary
- mark the menu bar asset as a template image so it is visible in light and dark menu bars
- fall back to a system symbol if the asset cannot be loaded
- use a square status item and centralize icon assignment through updateMenuBarIcon
- raise the translation panel to pop-up menu level so it appears above regular app windows

## Verification
- xcodebuild Release (GitHub) build
- scripts/release/package_macos.sh v9.9.9
- codesign --verify --deep --strict --verbose=2 artifacts/release/export/BarTranslateACO.app

Fixes #5