### PR TITLE
Suppress translate scrollbar in dark mode (Fixes #11)

### DIFF
--- a/BarTranslate/injections/style.swift
+++ b/BarTranslate/injections/style.swift
@@ -53,6 +53,21 @@ canvas,
 [role="img"] {
   filter: invert(100%) hue-rotate(180deg) !important;
 }
+
+html,
+body,
+* {
+  scrollbar-width: none !important;
+}
+
+html::-webkit-scrollbar,
+body::-webkit-scrollbar,
+*::-webkit-scrollbar {
+  width: 0 !important;
+  height: 0 !important;
+  display: none !important;
+}
+
 """
 }
 


### PR DESCRIPTION
## Summary
- suppress WebKit scrollbars in the dark-mode CSS injected into the translate page
- keeps the existing light-mode CSS unchanged
- settings page is unaffected because this CSS is injected only into the translate WebView

## Verification
- xcodebuild Release (GitHub) build
- scripts/release/package_macos.sh v9.9.9
- codesign --verify --deep --strict --verbose=2 artifacts/release/export/BarTranslateACO.app

Fixes #11