### PR TITLE
Add launch at login setting (Fixes #15)

### DIFF
--- a/BarTranslate.xcodeproj/project.pbxproj
+++ b/BarTranslate.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		45D1EF7C2A20DA300029FACD /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 45D1EF7B2A20DA300029FACD /* Assets.xcassets */; };
 		45D1EF7F2A20DA300029FACD /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 45D1EF7E2A20DA300029FACD /* Preview Assets.xcassets */; };
 		45E081CC2A68003E00D90780 /* DefaultSettings.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E081CB2A68003E00D90780 /* DefaultSettings.swift */; };
+		45E081CD2F70B00000B00001 /* LoginItemService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E081CE2F70B00000B00002 /* LoginItemService.swift */; };
 		45E1DB2D2A23312E00FA549C /* TopView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E1DB2C2A23312E00FA549C /* TopView.swift */; };
 		45E1DB2F2A23316F00FA549C /* TranslateView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E1DB2E2A23316F00FA549C /* TranslateView.swift */; };
 		45E44E562A23BEB500226A82 /* style.swift in Sources */ = {isa = PBXBuildFile; fileRef = 45E44E552A23BEB500226A82 /* style.swift */; };
@@ -42,6 +43,7 @@
 		45D1EF7E2A20DA300029FACD /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		45D1EF802A20DA300029FACD /* BarTranslate.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = BarTranslate.entitlements; sourceTree = "<group>"; };
 		45E081CB2A68003E00D90780 /* DefaultSettings.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultSettings.swift; sourceTree = "<group>"; };
+		45E081CE2F70B00000B00002 /* LoginItemService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LoginItemService.swift; sourceTree = "<group>"; };
 		45E1DB2C2A23312E00FA549C /* TopView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TopView.swift; sourceTree = "<group>"; };
 		45E1DB2E2A23316F00FA549C /* TranslateView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TranslateView.swift; sourceTree = "<group>"; };
 		45E44E552A23BEB500226A82 /* style.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = style.swift; sourceTree = "<group>"; };
@@ -95,6 +97,7 @@
 				45921B262A791991007AAD78 /* Bundle.swift */,
 				45C035312A21263500E304FF /* Constants.swift */,
 				45E081CB2A68003E00D90780 /* DefaultSettings.swift */,
+				45E081CE2F70B00000B00002 /* LoginItemService.swift */,
 				4585105A2A69BD0100C21BD0 /* KeysAndModifiers.swift */,
 				45A000032F13A00000000003 /* MenuIconStatus.png */,
 				45A000042F13A00000000004 /* MenuIconMinimalStatus.png */,
@@ -217,6 +220,7 @@
 				45D1EF7A2A20DA2D0029FACD /* ContentView.swift in Sources */,
 				45E44E562A23BEB500226A82 /* style.swift in Sources */,
 				45E081CC2A68003E00D90780 /* DefaultSettings.swift in Sources */,
+				45E081CD2F70B00000B00001 /* LoginItemService.swift in Sources */,
 				45921B272A791991007AAD78 /* Bundle.swift in Sources */,
 				4585105B2A69BD0100C21BD0 /* KeysAndModifiers.swift in Sources */,
 				45E1DB2F2A23316F00FA549C /* TranslateView.swift in Sources */,

--- a/BarTranslate/LoginItemService.swift
+++ b/BarTranslate/LoginItemService.swift
@@ -1,0 +1,77 @@
+//
+//  LoginItemService.swift
+//  BarTranslate
+//
+
+import Foundation
+import ServiceManagement
+
+struct LoginItemState: Equatable {
+  let enabled: Bool
+  let message: String?
+}
+
+enum LoginItemService {
+  static func currentState() -> LoginItemState {
+    guard #available(macOS 13.0, *) else {
+      return LoginItemState(
+        enabled: false,
+        message: "Launch at login requires macOS 13 or later."
+      )
+    }
+
+    switch SMAppService.mainApp.status {
+    case .enabled:
+      return LoginItemState(enabled: true, message: nil)
+    case .requiresApproval:
+      return LoginItemState(
+        enabled: true,
+        message: "Approval required: open System Settings → General → Login Items and allow BarTranslateACO."
+      )
+    case .notFound:
+      return LoginItemState(
+        enabled: false,
+        message: "macOS could not find BarTranslateACO.app. Launch at login only works from the packaged app bundle."
+      )
+    case .notRegistered:
+      return LoginItemState(enabled: false, message: nil)
+    @unknown default:
+      return LoginItemState(
+        enabled: false,
+        message: "macOS reported an unknown launch-at-login status."
+      )
+    }
+  }
+
+  static func setEnabled(_ enabled: Bool) -> LoginItemState {
+    guard #available(macOS 13.0, *) else {
+      return LoginItemState(
+        enabled: false,
+        message: "Launch at login requires macOS 13 or later."
+      )
+    }
+
+    do {
+      if enabled {
+        try SMAppService.mainApp.register()
+      } else {
+        try SMAppService.mainApp.unregister()
+      }
+    } catch {
+      return LoginItemState(
+        enabled: currentState().enabled,
+        message: errorMessage(for: enabled, error: error)
+      )
+    }
+
+    return currentState()
+  }
+
+  private static func errorMessage(for enabled: Bool, error: Error) -> String {
+    if enabled {
+      return "Could not enable launch at login: \(error.localizedDescription)"
+    }
+
+    return "Could not disable launch at login: \(error.localizedDescription)"
+  }
+}

--- a/BarTranslate/views/SettingsView.swift
+++ b/BarTranslate/views/SettingsView.swift
@@ -17,6 +17,8 @@ struct SettingsView: View {
     @AppStorage("showHideModifier") private var showHideModifier: String = DefaultSettings.ToggleApp.modifier.description
     @AppStorage("menuBarIcon") private var menuBarIcon: MenuBarIcon = DefaultSettings.menuBarIcon
     @AppStorage("autoClipboardPaste") private var autoClipboardPaste: Bool = false
+    @State private var launchAtLogin: Bool = false
+    @State private var launchAtLoginMessage: String?
 
     var body: some View {
         ScrollView(.vertical, showsIndicators: false) {
@@ -85,6 +87,25 @@ struct SettingsView: View {
                         Toggle("", isOn: $autoClipboardPaste)
                             .labelsHidden()
                     }
+
+                    SettingsRow(label: "Launch at login") {
+                        Toggle("", isOn: Binding(
+                            get: { launchAtLogin },
+                            set: { enabled in
+                                let state = LoginItemService.setEnabled(enabled)
+                                launchAtLogin = state.enabled
+                                launchAtLoginMessage = state.message
+                            }
+                        ))
+                        .labelsHidden()
+                    }
+
+                    if let launchAtLoginMessage = launchAtLoginMessage {
+                        Text(launchAtLoginMessage)
+                            .font(.system(size: 11))
+                            .foregroundColor(.secondary)
+                            .padding(.horizontal, 12)
+                    }
                 }
 
                 // About
@@ -135,6 +156,11 @@ struct SettingsView: View {
         }
         .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
         .background(Color(NSColor.windowBackgroundColor))
+        .onAppear {
+            let state = LoginItemService.currentState()
+            launchAtLogin = state.enabled
+            launchAtLoginMessage = state.message
+        }
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds a Behavior setting to enable or disable launch at login.
- Uses macOS SMAppService main app registration with macOS 13 availability checks.
- Refreshes the toggle from the OS login-item status and surfaces approval, not found, unsupported, and registration error messages in Settings.

## Verification

- xcodebuild Release GitHub build succeeded.
- scripts/release/package_macos.sh v9.9.9 succeeded and verified codesign.

No new secrets are required.