### PR TITLE
Add Google account access from settings (Fixes #38)

### DIFF
--- a/BarTranslate/BarTranslateApp.swift
+++ b/BarTranslate/BarTranslateApp.swift
@@ -21,7 +21,7 @@ struct BarTranslateApp: App {
       CommandGroup(replacing: CommandGroupPlacement.newItem) {}
     }
     Settings {
-      SettingsView()
+      SettingsView(BT: appDelegate.BT)
     }
   }
 }
@@ -67,17 +67,51 @@ class BarTranslate: ObservableObject {
     set { UserDefaults.standard.set(newValue, forKey: "lastTargetLang") }
   }
 
-  func reloadWebView(for provider: TranslationProvider) {
+  private func googleTranslateURL() -> URL {
+    var components = URLComponents()
+    components.scheme = "https"
+    components.host = "translate.google.com"
+    components.path = "/"
+    components.queryItems = [
+      URLQueryItem(name: "sl", value: lastSourceLang),
+      URLQueryItem(name: "tl", value: lastTargetLang),
+      URLQueryItem(name: "op", value: "translate")
+    ]
+
+    return components.url!
+  }
+
+  func loadURL(_ url: URL, provider: TranslationProvider) {
     guard let webView = webView else { return }
 
-    let sl = lastSourceLang
-    let tl = lastTargetLang
-    let urlString = "https://translate.google.com/?sl=\(sl)&tl=\(tl)&op=translate"
-    let providerURL = URL(string: urlString)!
-    let request = URLRequest(url: providerURL)
+    isLoading = true
+    let request = URLRequest(url: url)
 
     injectCSS(webView: webView, provider: provider)
     webView.load(request)
+  }
+
+  func reloadWebView(for provider: TranslationProvider) {
+    loadURL(googleTranslateURL(), provider: provider)
+  }
+
+  func openGoogleSignIn(provider: TranslationProvider) {
+    var components = URLComponents()
+    components.scheme = "https"
+    components.host = "accounts.google.com"
+    components.path = "/ServiceLogin"
+    components.queryItems = [
+      URLQueryItem(name: "continue", value: googleTranslateURL().absoluteString)
+    ]
+
+    if let url = components.url {
+      loadURL(url, provider: provider)
+    }
+  }
+
+  func openGoogleTranslateHistory(provider: TranslationProvider) {
+    guard let url = URL(string: "https://translate.google.com/history") else { return }
+    loadURL(url, provider: provider)
   }
 }
 

--- a/BarTranslate/BarTranslateApp.swift
+++ b/BarTranslate/BarTranslateApp.swift
@@ -109,6 +109,20 @@ class BarTranslate: ObservableObject {
     }
   }
 
+  func openGoogleSignOut(provider: TranslationProvider) {
+    var components = URLComponents()
+    components.scheme = "https"
+    components.host = "accounts.google.com"
+    components.path = "/Logout"
+    components.queryItems = [
+      URLQueryItem(name: "continue", value: googleTranslateURL().absoluteString)
+    ]
+
+    if let url = components.url {
+      loadURL(url, provider: provider)
+    }
+  }
+
   func openGoogleTranslateHistory(provider: TranslationProvider) {
     guard let url = URL(string: "https://translate.google.com/history") else { return }
     loadURL(url, provider: provider)

--- a/BarTranslate/views/ContentView.swift
+++ b/BarTranslate/views/ContentView.swift
@@ -27,7 +27,7 @@ struct ContentView: View {
           .allowsHitTesting(BT.currentView == .translate)
           .opacity(BT.currentView == .translate ? 1 : 0)
 
-        SettingsView()
+        SettingsView(BT: BT)
           .zIndex(BT.currentView == .translate ? 0 : 2)
           .allowsHitTesting(BT.currentView == .settings)
           .opacity(BT.currentView == .settings ? 1 : 0)

--- a/BarTranslate/views/SettingsView.swift
+++ b/BarTranslate/views/SettingsView.swift
@@ -37,11 +37,19 @@ struct SettingsView: View {
                     }
 
                     SettingsRow(label: "Google account") {
-                        Button("Sign in") {
-                            BT.openGoogleSignIn(provider: translationProvider)
-                            BT.currentView = .translate
+                        HStack(spacing: 8) {
+                            Button("Sign in") {
+                                BT.openGoogleSignIn(provider: translationProvider)
+                                BT.currentView = .translate
+                            }
+                            .font(.system(size: 12))
+
+                            Button("Sign out") {
+                                BT.openGoogleSignOut(provider: translationProvider)
+                                BT.currentView = .translate
+                            }
+                            .font(.system(size: 12))
                         }
-                        .font(.system(size: 12))
                     }
 
                     SettingsRow(label: "Translation history") {

--- a/BarTranslate/views/SettingsView.swift
+++ b/BarTranslate/views/SettingsView.swift
@@ -12,6 +12,7 @@ import HotKey
 
 struct SettingsView: View {
 
+    @ObservedObject var BT: BarTranslate
     @AppStorage("translationProvider") private var translationProvider: TranslationProvider = DefaultSettings.translationProvider
     @AppStorage("showHideKey") private var showHideKey: String = DefaultSettings.ToggleApp.key.description
     @AppStorage("showHideModifier") private var showHideModifier: String = DefaultSettings.ToggleApp.modifier.description
@@ -33,6 +34,22 @@ struct SettingsView: View {
                         .pickerStyle(.menu)
                         .labelsHidden()
                         .frame(width: 140)
+                    }
+
+                    SettingsRow(label: "Google account") {
+                        Button("Sign in") {
+                            BT.openGoogleSignIn(provider: translationProvider)
+                            BT.currentView = .translate
+                        }
+                        .font(.system(size: 12))
+                    }
+
+                    SettingsRow(label: "Translation history") {
+                        Button("Open history") {
+                            BT.openGoogleTranslateHistory(provider: translationProvider)
+                            BT.currentView = .translate
+                        }
+                        .font(.system(size: 12))
                     }
                 }
 
@@ -212,7 +229,7 @@ struct SettingsRow<Trailing: View>: View {
 
 struct SettingsView_Previews: PreviewProvider {
     static var previews: some View {
-        SettingsView()
+        SettingsView(BT: BarTranslate())
             .frame(
                 minWidth: Constants.AppSize.width,
                 maxWidth: Constants.AppSize.width,


### PR DESCRIPTION
## Summary
- Add Settings actions to open Google sign-in and Google Translate history in the embedded web view
- Preserve the current Google Translate language pair when returning from sign-in
- Route Settings through the shared app state so it can navigate the translator web view

## Verification
- xcodebuild -project BarTranslate.xcodeproj -scheme "BarTranslate (Debug)" -configuration Debug -derivedDataPath .build/DerivedData CODE_SIGNING_ALLOWED=NO build

Fixes ThijmenDam/BarTranslate#38