### PR TITLE
Fix IME candidate panel ordering (Upstream #58)

### DIFF
--- a/BarTranslate/BarTranslateApp.swift
+++ b/BarTranslate/BarTranslateApp.swift
@@ -244,7 +244,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
       backing: .buffered,
       defer: false)
     panel.isFloatingPanel = true
-    panel.level = .popUpMenu
+    panel.level = .normal
     panel.collectionBehavior = [.canJoinAllSpaces, .fullScreenAuxiliary]
     panel.contentViewController = NSHostingController(rootView: contentView)
     panel.isMovableByWindowBackground = false


### PR DESCRIPTION
Adapts upstream PR #69 from ThijmenDam/BarTranslate for this fork.\n\nSummary:\n- Lower the BarTranslateACO panel window level from pop-up-menu level to normal level.\n- Keeps this fork's existing NSPanel, KeyablePanel, styling, positioning, and release changes intact.\n- Allows macOS IME candidate windows, including Chinese Pinyin, to appear above the translation panel.\n\nVerification:\n- xcodebuild -project BarTranslate.xcodeproj -scheme "BarTranslate (Debug)" -configuration Debug -destination 'platform=macOS' build failed only because the configured Mac Development certificate is unavailable locally.\n- xcodebuild -project BarTranslate.xcodeproj -scheme "BarTranslate (Debug)" -configuration Debug -destination 'platform=macOS' CODE_SIGNING_ALLOWED=NO CODE_SIGN_IDENTITY= build succeeded.