### PR TITLE
Add main menu with Edit submenu to enable standard edit shortcuts (Fixes #24)

### DIFF
--- a/BarTranslate/BarTranslateApp.swift
+++ b/BarTranslate/BarTranslateApp.swift
@@ -120,7 +120,34 @@ enum BarTranslateApplication {
   static func main() {
     let application = NSApplication.shared
     application.delegate = appDelegate
+    application.mainMenu = buildMainMenu()
     application.run()
+  }
+
+  private static func buildMainMenu() -> NSMenu {
+    let mainMenu = NSMenu()
+
+    // Application submenu (required for macOS to recognize the menu bar)
+    let appMenuItem = NSMenuItem()
+    mainMenu.addItem(appMenuItem)
+    let appSubmenu = NSMenu(title: "BarTranslateACO")
+    appSubmenu.addItem(withTitle: "Quit BarTranslateACO", action: #selector(NSApplication.terminate(_:)), keyEquivalent: "q")
+    appMenuItem.submenu = appSubmenu
+
+    // Edit submenu — provides standard Cmd+C/V/A etc. shortcuts
+    let editMenuItem = NSMenuItem()
+    mainMenu.addItem(editMenuItem)
+    let editSubmenu = NSMenu(title: "Edit")
+    editSubmenu.addItem(withTitle: "Undo", action: Selector(("undo:")), keyEquivalent: "z")
+    editSubmenu.addItem(withTitle: "Redo", action: Selector(("redo:")), keyEquivalent: "Z")
+    editSubmenu.addItem(NSMenuItem.separator())
+    editSubmenu.addItem(withTitle: "Cut", action: #selector(NSText.cut(_:)), keyEquivalent: "x")
+    editSubmenu.addItem(withTitle: "Copy", action: #selector(NSText.copy(_:)), keyEquivalent: "c")
+    editSubmenu.addItem(withTitle: "Paste", action: #selector(NSText.paste(_:)), keyEquivalent: "v")
+    editSubmenu.addItem(withTitle: "Select All", action: #selector(NSText.selectAll(_:)), keyEquivalent: "a")
+    editMenuItem.submenu = editSubmenu
+
+    return mainMenu
   }
 }
 


### PR DESCRIPTION
## Problem

Reported by @MononoXL in [ThijmenDam/BarTranslate#69 (comment)](https://github.com/ThijmenDam/BarTranslate/pull/69#issuecomment-4361860018).

After the IME candidate window fix was released in bartranslate-aco 2.1.8, Cmd+C/V/A standard macOS edit shortcuts do not work inside the panel. Right-click Paste works fine, but keyboard shortcuts are not routed correctly.

## Root Cause

The app uses a manual AppKit lifecycle (`NSApplication.shared` + `AppDelegate`) rather than the SwiftUI App lifecycle with `@NSApplicationDelegateAdaptor`. The manual approach bypasses the default SwiftUI menu bar, which means macOS has **no Edit menu** to route Cmd+C/V/A through the responder chain. Without menu items defining those key equivalents, macOS simply beeps and ignores the shortcuts.

## Fix

Add a programmatic main menu in `BarTranslateApplication.main()` before starting the event loop. The menu includes:

- **Application submenu**: Quit BarTranslateACO (Cmd+Q)
- **Edit submenu**: Undo (Cmd+Z), Redo (Cmd+Shift+Z), Cut (Cmd+X), Copy (Cmd+C), Paste (Cmd+V), Select All (Cmd+A)

The Edit menu items use standard AppKit selectors (`NSText.cut(_:)`, `NSText.copy(_:)`, etc.) which macOS automatically routes through the responder chain to the current first responder (e.g., a text field in the WKWebView).

## Testing

- Build succeeds with no compilation errors
- The menu items and key equivalents are standard macOS patterns that rely on automatic menu enabling via the responder chain

Credit: @MononoXL for diagnosing the root cause and reporting the issue.