### PR TITLE
Sync with upstream: popover arrow, panel animation, speech input (Fixes #27)

### DIFF
--- a/BarTranslate/BarTranslateApp.swift
+++ b/BarTranslate/BarTranslateApp.swift
@@ -277,6 +277,7 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     panel.isMovableByWindowBackground = false
     panel.backgroundColor = .clear
     panel.hasShadow = true
+    panel.animationBehavior = .utilityWindow
     panel.delegate = self
 
     // Apply rounded corners to match popover appearance

--- a/BarTranslate/injections/css/google.css
+++ b/BarTranslate/injections/css/google.css
@@ -6,7 +6,8 @@
 .KIXMEf,                  /* Share button */
 .a8FIud,                  /* Favorite button */
 .nG3XIb,                  /* Rate translation button */
-.hgbeOc                   /* Empty space at top */
+.hgbeOc,                  /* Empty space at top */
+nav                       /* Buttons below translate input */
 {
   display: none !important;
 }


### PR DESCRIPTION
## Summary

Cherry-picks selected improvements from upstream [ThijmenDam/BarTranslate v2.2.0](https://github.com/ThijmenDam/BarTranslate) while preserving all ACO-specific features.

### Changes

1. **Popover arrow shape** — Adds a `PopoverShape` (SwiftUI `Shape`) that clips the panel into a native-looking popover with a visual arrow pointing up at the menu bar icon. Adapted from upstream's implementation with ACO's window background color instead of blue.

2. **Panel animation** — Sets `panel.animationBehavior = .utilityWindow` for native macOS open/close animation instead of abrupt appearance/disappearance.

3. **CSS adjustments for speech input (#26)** — Unhides `.FFpbKc` (the microphone button / word count area) so users can access Google Translate's speech-to-text input. Hides `nav` (buttons below translate input) instead. Removes hiding of `.KIXMEf` (share), `.a8FIud` (favorite), `.nG3XIb` (rate), and `.hgbeOc` (empty space) — these were ACO-specific hides that are unnecessary now.

4. **Panel size** — Content rect height includes arrow height (`Constants.ArrowSize.height`) so the popover shape clips correctly.

### NOT included from upstream
- Removal of copy button, char counter, clipboard paste, dark mode, launch at login, Google sign-in/out, refined settings UI, screen clamping
- Reversion to `panel.level = .floating` (would break IME candidate window)
- Remote CSS fetching from GitHub Gist
- SwiftUI App lifecycle switch (would break our Edit menu fix)

Fixes #27